### PR TITLE
Remove defaultProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,14 @@ const drawSvgBars = (encodings, options = {}) => {
 
 export default function Barcode(props) {
   const {
-    value, format, singleBarWidth, maxWidth, height, lineColor, backgroundColor, onError,
+    value = '', 
+    format = 'CODE128', 
+    singleBarWidth = 2, 
+    maxWidth, 
+    height = 100, 
+    lineColor = '#000000', 
+    backgroundColor = '#FFFFFF', 
+    onError,
   } = props;
   const [bars, setBars] = useState([]);
   const [barcodeWidth, setBarCodeWidth] = useState(0);
@@ -170,17 +177,6 @@ Barcode.propTypes = {
   lineColor: PropTypes.string,
   backgroundColor: PropTypes.string, // background
   onError: PropTypes.func,
-};
-
-Barcode.defaultProps = {
-  value: '',
-  format: 'CODE128',
-  singleBarWidth: 2, // width
-  maxWidth: undefined,
-  height: 100,
-  lineColor: '#000000',
-  backgroundColor: '#FFFFFF',
-  onError: undefined,
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
We are using this library but get the following warning
```
Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
```

Would it be possible to make a release with this change?